### PR TITLE
fix: add 401 http status handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "startingfromscratch",
-  "version": "1.0.0",
-  "description": "",
+  "name": "parcellab-chrome-extension",
+  "version": "0.5.2",
+  "description": "parcelLab Chrome plugin for Customer Service teams to retrieve and display trackings from parcelLab",
   "scripts": {
     "start": "webpack --watch --progress --config webpack.dev.cjs",
     "build": "webpack --progress --config webpack.prod.cjs",

--- a/src/api.ts
+++ b/src/api.ts
@@ -21,7 +21,11 @@ export function getOrderByOrderNumber(searchTerm, options) {
       // StorageService.saveLastResult() //- bring me back
     })
     .fail(function (response) {
-      if ((response.status == 403)) {
+      if (response.status == 401) {
+        stopProgress()
+				displayAlert(401)
+				$('#search-btn').prop('disabled', false);
+      } else if (response.status == 403) {
         stopProgress()
         displayAlert(403)
         $('#search-btn').prop('disabled', false)

--- a/src/ux.ts
+++ b/src/ux.ts
@@ -249,19 +249,23 @@ export function displayAlert(status) {
   let alertType
 
   switch (status) {
-    case 400:
-      message = 'Please enter an order number and try again'
-      alertType = 'warning'
-      break
-    case 403:
-      message = 'Please check your authorization credentials and try again'
-      alertType = 'danger'
-      break
-    case 404:
-      message = 'No records found'
-      alertType = 'info'
-      break
-  }
+		case 400:
+			message = 'Please enter an order number and try again';
+			alertType = 'warning';
+			break;
+		case 401:
+			message = 'Please check your authorization credentials and try again';
+			alertType = 'danger';
+			break;
+		case 403:
+			message = 'Please check your authorization credentials and try again';
+			alertType = 'danger';
+			break;
+		case 404:
+			message = 'No records found';
+			alertType = 'info';
+			break;
+	}
   $('#search-area').after(
     `<div id="fail-alert" class="alert alert-${alertType}" role="alert">${message}</div>`
   )

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "parcelLab",
-  "version": "0.5.1",
-  "version_name": "0.5.1 beta",
+  "version": "0.5.2",
+  "version_name": "0.5.2 beta",
   "description": "parcelLab Chrome plugin for Customer Service teams to retrieve and display trackings from parcelLab",
   "author": "jay@parcellab.com",
   "icons": {


### PR DESCRIPTION
Addresses issue: https://github.com/parcelLab/parcellab-chrome-plugin/issues/3

## Description

In the event that an API returns HTTP status 401 the application will unblock and provide an appropriate error message to the user.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] No documentation update is required