### PR TITLE
feat: added email popovers

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "semi": true,
+  "semi": false,
   "singleQuote": true,
   "trailingComma": "all",
   "printWidth": 80,

--- a/src/api.ts
+++ b/src/api.ts
@@ -2,7 +2,7 @@ import {
 	processBotOrder,
 	processJourneyCheckpoints,
 	processBotOrders,
-} from './popup';
+} from './popup'
 import { subtractDays } from './utility'
 import { stopProgress, displayAlert } from './ux'
 
@@ -20,105 +20,104 @@ export function getOrdersFromChatBotAPI(searchTerm, searchType, options) {
 			'content-type': 'application/json',
 			Authorization: 'Basic ' + btoa(options.user + ':' + options.token),
 		},
-	};
+	}
 
-  $.ajax(settings)
+	$.ajax(settings)
 		.done(function (response) {
-			processBotOrders(response);
-			$('#search-btn').prop('disabled', false);
+			processBotOrders(response)
+			$('#search-btn').prop('disabled', false)
 		})
 		.fail(function (response) {
 			if (response.status == 401) {
-				stopProgress();
-				displayAlert(401);
-				$('#search-btn').prop('disabled', false);
+				stopProgress()
+				displayAlert(401)
+				$('#search-btn').prop('disabled', false)
 			} else if (response.status == 403) {
-				stopProgress();
-				displayAlert(403);
-				$('#search-btn').prop('disabled', false);
+				stopProgress()
+				displayAlert(403)
+				$('#search-btn').prop('disabled', false)
 			} else if (response.status == 404) {
-				stopProgress();
-				displayAlert(404);
-				$('#search-btn').prop('disabled', false);
+				stopProgress()
+				displayAlert(404)
+				$('#search-btn').prop('disabled', false)
 			}
-		});
+		})
 }
 
-
 export function getOrderByOrderNumber(searchTerm, options) {
-  const settings = {
-    url: `${baseURL}/orders/bot?showReturns=true&orderNo=${searchTerm}&lang=${options.language}`,
-    method: 'GET',
-    timeout: 0,
-    async: true,
-    headers: {
-      'content-type': 'application/json',
-      Authorization: 'Basic ' + btoa(options.user + ':' + options.token),
-    },
-  }
+	const settings = {
+		url: `${baseURL}/orders/bot?showReturns=true&orderNo=${searchTerm}&lang=${options.language}`,
+		method: 'GET',
+		timeout: 0,
+		async: true,
+		headers: {
+			'content-type': 'application/json',
+			Authorization: 'Basic ' + btoa(options.user + ':' + options.token),
+		},
+	}
 
-  $.ajax(settings)
-    .done(function (response) {
-      processBotOrder(response, false, )
-      $('#search-btn').prop('disabled', false)
-      // StorageService.saveLastResult() //- bring me back
-    })
-    .fail(function (response) {
-      if (response.status == 401) {
-        stopProgress()
+	$.ajax(settings)
+		.done(function (response) {
+			processBotOrder(response, false)
+			$('#search-btn').prop('disabled', false)
+			// StorageService.saveLastResult() //- bring me back
+		})
+		.fail(function (response) {
+			if (response.status == 401) {
+				stopProgress()
 				displayAlert(401)
-				$('#search-btn').prop('disabled', false);
-      } else if (response.status == 403) {
-        stopProgress()
-        displayAlert(403)
-        $('#search-btn').prop('disabled', false)
-      } else {
-        getOrderNumberByTrackingNumber(searchTerm, options)
-      }
-    })
+				$('#search-btn').prop('disabled', false)
+			} else if (response.status == 403) {
+				stopProgress()
+				displayAlert(403)
+				$('#search-btn').prop('disabled', false)
+			} else {
+				getOrderNumberByTrackingNumber(searchTerm, options)
+			}
+		})
 }
 
 function getOrderNumberByTrackingNumber(searchTerm, options) {
-  const date = new Date()
-  const fromDate = subtractDays(date, 120)
-  const fromDateFormatted = fromDate.toJSON().slice(0, 10)
+	const date = new Date()
+	const fromDate = subtractDays(date, 120)
+	const fromDateFormatted = fromDate.toJSON().slice(0, 10)
 
-  const settings = {
-    url: `${baseURL}/v2/search/?s=${searchTerm}&from=${fromDateFormatted}&lang=${options.language}`,
-    method: 'GET',
-    timeout: 0,
-    async: true,
-    headers: {
-      'content-type': 'application/json',
-      Authorization: 'Basic ' + btoa(options.user + ':' + options.token),
-    },
-  }
+	const settings = {
+		url: `${baseURL}/v2/search/?s=${searchTerm}&from=${fromDateFormatted}&lang=${options.language}`,
+		method: 'GET',
+		timeout: 0,
+		async: true,
+		headers: {
+			'content-type': 'application/json',
+			Authorization: 'Basic ' + btoa(options.user + ':' + options.token),
+		},
+	}
 
-  $.ajax(settings).done(function (response) {
-    if (response.meta.hits == 0) {
-      stopProgress()
-      displayAlert(404)
-      $('#search-btn').prop('disabled', false)
-    } else {
-      const orderNumber = response.results[0].inf.orn
-      getOrderByOrderNumber(orderNumber, options)
-    }
-  })
+	$.ajax(settings).done(function (response) {
+		if (response.meta.hits == 0) {
+			stopProgress()
+			displayAlert(404)
+			$('#search-btn').prop('disabled', false)
+		} else {
+			const orderNumber = response.results[0].inf.orn
+			getOrderByOrderNumber(orderNumber, options)
+		}
+	})
 }
 
 export function getNotifications(parcel, options, orderNo, pCounter) {
-  const settings = {
-    url: `${baseURL}/v2/notifications?tid=${parcel.id}&lang=${options.language}`,
-    method: 'GET',
-    timeout: 0,
-    async: true,
-    headers: {
-      'content-type': 'application/json',
-      Authorization: 'Basic ' + btoa(options.user + ':' + options.token),
-    },
-  }
+	const settings = {
+		url: `${baseURL}/v2/notifications?tid=${parcel.id}&lang=${options.language}`,
+		method: 'GET',
+		timeout: 0,
+		async: true,
+		headers: {
+			'content-type': 'application/json',
+			Authorization: 'Basic ' + btoa(options.user + ':' + options.token),
+		},
+	}
 
-  $.ajax(settings).always(function (response) {
-    processJourneyCheckpoints(response, parcel, orderNo, pCounter)
-  })
+	$.ajax(settings).always(function (response) {
+		processJourneyCheckpoints(response, parcel, orderNo, pCounter)
+	})
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -9,46 +9,44 @@ import { getOptions, setOptions, StorageOptions } from './storage'
 const { user, token, language } = getOptions()
 
 if (user !== undefined) {
-    $('#user').val(user)
+	$('#user').val(user)
 }
 if (token !== undefined) {
-    $('#token').val(token)
+	$('#token').val(token)
 }
 if (language !== undefined) {
-    $('#language').val(language)
+	$('#language').val(language)
 }
 
-
 $(document).ready(function () {
+	$('.fc').on('change', function () {
+		if ($(this).val() == '') {
+			$(this).addClass('is-invalid')
+		} else {
+			$(this).removeClass('is-invalid')
+		}
+	})
 
-    $('.fc').on('change', function () {
-        if ( $(this).val() == '' ) {
-            $(this).addClass('is-invalid')
-        } else {
-            $(this).removeClass('is-invalid')
-        }
-    })
+	$('#save-btn').on('click', function () {
+		let valid = true
+		const options: StorageOptions = { user, token, language }
+		type ObjectKey = keyof typeof options
 
-    $('#save-btn').on('click', function () {
-        let valid = true
-        const options:StorageOptions = {user, token, language}
-        type ObjectKey = keyof typeof options
+		$('.fc').each(function () {
+			const val: string = $(this).val() as string
 
-        $('.fc').each(function () {
-            const val:string = $(this).val() as string
+			if (val == '') {
+				$(this).addClass('is-invalid')
+				valid = false
+			} else {
+				const myKey = $(this).attr('id') as ObjectKey
+				options[myKey] = val
+			}
+		})
 
-            if (val == '') {
-                $(this).addClass('is-invalid')
-                valid = false
-            } else {
-                const myKey = $(this).attr('id') as ObjectKey
-                options[myKey] = val
-            }   
-        })
-
-        if (valid) {
-            setOptions(options)
-            window.close()
-        }
-    })
+		if (valid) {
+			setOptions(options)
+			window.close()
+		}
+	})
 })

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,242 +1,277 @@
 // Import our custom CSS
 import '../styles/common.scss'
 
-// Import all of Bootstrap's JS
-//import * as bootstrap from 'bootstrap'
-
-import { getOptions, StorageOptions, getLastResult, setLastResult } from './storage'
+import {
+	getOptions,
+	StorageOptions,
+	getLastResult,
+	setLastResult,
+} from './storage'
 import * as UX from './ux'
 import {
 	isEmail,
 	mergeAndSortAscendingDate,
 	filterHiddenEvents,
 	sortByColorPriority,
-} from './utility';
+} from './utility'
 import {
 	getOrderByOrderNumber,
 	getNotifications,
 	getOrdersFromChatBotAPI,
-} from './api';
+} from './api'
 
 require('bootstrap-icons/font/bootstrap-icons.css')
 
-const options:StorageOptions = getOptions()
+const options: StorageOptions = getOptions()
 
 export function processBotOrders(response) {
-  //this should replace processBotOrder [singular] as it will handle single and multi orders(??)
-  UX.stopProgress()
-  UX.addOrderHeader(response.orders, true);
+	//this should replace processBotOrder [singular] as it will handle single and multi orders(??)
+	UX.stopProgress()
+	UX.addOrderHeader(response.orders, true)
 
-  if (response.orders.length > 1) {
-    let panelIndex = response.orders.length
-    for (const order of response.orders) {
-			UX.addOrderCard(order, panelIndex);
-			panelIndex--;
+	if (response.orders.length > 1) {
+		let panelIndex = response.orders.length
+		for (const order of response.orders) {
+			UX.addOrderCard(order, panelIndex)
+			panelIndex--
 			for (const parcel of order.parcels) {
 				UX.addMultiOrderTracking(parcel, order.orderNo)
 			}
 			// this is where we want to populate the subcard
 			const subOrder = { orders: [order] }
-      processBotOrder(subOrder, true)
+			processBotOrder(subOrder, true)
 		}
-  
-  }
+	}
 
-  UX.enableControls();
+	UX.enableControls()
 }
 
-
 export function processBotOrder(response, multiOrder: boolean) {
-	
-
-	UX.stopProgress();
+	UX.stopProgress()
 
 	//const parcelsCount = response.orders[0].parcels.length
 	const outboundCount = response.orders[0].parcels.filter(
 		(p) => p.isReturn === false,
-	).length;
+	).length
 	const returnCount = response.orders[0].parcels.filter(
 		(p) => p.isReturn === true,
-	).length;
+	).length
 
 	//initial order information
-	UX.addOrderHeader(response.orders, multiOrder);
+	UX.addOrderHeader(response.orders, multiOrder)
 
-	let i = 0;
-	let oIndex = 0;
-	let rIndex = 0;
-	let displayIndex = 0;
-	let displayCount = 0;
-	let packageText;
+	let i = 0
+	let oIndex = 0
+	let rIndex = 0
+	let displayIndex = 0
+	let displayCount = 0
+	let packageText
 
 	const parcels = sortByColorPriority(response.orders[0].parcels)
-  const orderNo = response.orders[0].orderNo
+	const orderNo = response.orders[0].orderNo
 
 	for (const parcel of parcels) {
-    const trackingNumber = parcel.tracking_number
+		const trackingNumber = parcel.tracking_number
 
-		i++;
+		i++
 		if (parcel.isReturn === true) {
-			rIndex++;
-			displayIndex = rIndex;
-			displayCount = returnCount;
-			packageText = 'Return package';
+			rIndex++
+			displayIndex = rIndex
+			displayCount = returnCount
+			packageText = 'Return package'
 		} else {
-			oIndex++;
-			displayIndex = oIndex;
-			displayCount = outboundCount;
-			packageText = 'Package';
+			oIndex++
+			displayIndex = oIndex
+			displayCount = outboundCount
+			packageText = 'Package'
 		}
 
 		// add tracking card
-		UX.addTrackingCard(parcel, orderNo, i, packageText, displayIndex, displayCount);
+		UX.addTrackingCard(
+			parcel,
+			orderNo,
+			i,
+			packageText,
+			displayIndex,
+			displayCount,
+		)
 
 		//add subsections
-		UX.addSubCards(parcel, orderNo, i);
+		UX.addSubCards(parcel, orderNo, i)
 
 		// get notifications
-		getNotifications(parcel, options, orderNo, i);
+		getNotifications(parcel, options, orderNo, i)
 
 		//add product details header
-		UX.addProductDetailsHeader(trackingNumber, orderNo);
+		UX.addProductDetailsHeader(trackingNumber, orderNo)
 
 		//start product loop
-		UX.addProductDetails(parcel.delivery_info.articles, orderNo, trackingNumber);
+		UX.addProductDetails(parcel.delivery_info.articles, orderNo, trackingNumber)
 	} //end tracking loop
 
-	UX.enableControls();
-	setLastResult($('#resultsPanel').html());
+	UX.enableControls()
+	setLastResult($('#resultsPanel').html())
 }
 
 export function processJourneyCheckpoints(response, parcel, orderNo, pCounter) {
-  if (typeof response.status !== undefined) {
-    //merge notifications with checkpoints for full journey
-    let cpNotificationsSorted = mergeAndSortAscendingDate(
-      parcel.checkpoints,
-      response
-    )
+	if (typeof response.status !== undefined) {
+		//merge notifications with checkpoints for full journey
+		let cpNotificationsSorted = mergeAndSortAscendingDate(
+			parcel.checkpoints,
+			response,
+		)
 
-    //filter out hidden events
-    cpNotificationsSorted = filterHiddenEvents(cpNotificationsSorted)
+		//filter out hidden events
+		cpNotificationsSorted = filterHiddenEvents(cpNotificationsSorted)
 
-    //populate shipment details
-    for (let cp = cpNotificationsSorted.length - 1; cp >= 0; cp--) {
-      const checkpoint = cpNotificationsSorted[cp]
+		//populate shipment details
+		for (let cp = cpNotificationsSorted.length - 1; cp >= 0; cp--) {
+			const checkpoint = cpNotificationsSorted[cp]
 
-      let cpStatus
-      let cpTitle
-      let cpSubTitle
-      let icon
-      let oDate
-      let cDate
-      let svgClass
-      let emailClass
-      let infoHtml
+			let cpStatus
+			let cpTitle
+			let cpSubTitle
+			let icon
+			let oDate
+			let cDate
+			let svgClass
+			let emailClass
+			let infoHtml
+			let emailPopover
+			let attachmentsCode
+			let attachmentsLinks
 
-      //if (checkpoint.hasOwnProperty('type')) {
-      if ( Object.prototype.hasOwnProperty.call(checkpoint,'type') ){
-        // is a notification
-        cpStatus = checkpoint.type
-      } else {
-        // is a checkpoint
-        cpStatus = checkpoint.status_text
-        cpTitle = checkpoint.status_text
-        cpSubTitle = checkpoint.status_details
-      }
+			if (Object.prototype.hasOwnProperty.call(checkpoint, 'type')) {
+				// is a notification
+				cpStatus = checkpoint.type
+			} else {
+				// is a checkpoint
+				cpStatus = checkpoint.status_text
+				cpTitle = checkpoint.status_text
+				cpSubTitle = checkpoint.status_details
+			}
 
-      const date = new Date(checkpoint.timestamp)
-      svgClass = ' icon-svg-std'
-      emailClass = ''
-      infoHtml = ''
+			const date = new Date(checkpoint.timestamp)
+			svgClass = ' icon-svg-std'
+			emailClass = ''
+			infoHtml = ''
 
-      switch (cpStatus) {
-        case 'Delivered':
-          //icon = 'bi-check-circle-fill'
-          icon = 
-            `
+			if (typeof checkpoint.opened === 'string') {
+				oDate = new Date(checkpoint.opened).toLocaleString('en-US', {
+					month: 'long',
+					day: 'numeric',
+				})
+			} else {
+				oDate = '--'
+			}
+
+			if (typeof checkpoint.clicked === 'string') {
+				cDate = new Date(checkpoint.clicked).toLocaleString('en-US', {
+					month: 'long',
+					day: 'numeric',
+				})
+			} else {
+				cDate = '--'
+			}
+
+			switch (cpStatus) {
+				case 'Delivered':
+					icon = `
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#FFFFFF" class="bi bi-check-lg" viewBox="0 0 16 16">
                 <path d="M12.736 3.97a.733.733 0 0 1 1.047 0c.286.289.29.756.01 1.05L7.88 12.01a.733.733 0 0 1-1.065.02L3.217 8.384a.757.757 0 0 1 0-1.06.733.733 0 0 1 1.047 0l3.052 3.093 5.4-6.425a.247.247 0 0 1 .02-.022Z"/>
               </svg>
             `
-              //           icon = `<svg class="svg-snoweb svg-theme-light" height="100" preserveaspectratio="xMidYMid meet" viewbox="0 0 100 100" width="100" x="0" xmlns="http://www.w3.org/2000/svg" y="0">
-              //  <path style="fill: #002172;" d="M50,87.4c20.655,0,37.4-16.745,37.4-37.4S70.655,12.6,50,12.6,12.6,29.345,12.6,50h0c-.055,20.6,16.6,37.345,37.2,37.4,.067,0,.134,0,.2,0Zm17.3-43.4c1.85-1.821,1.874-4.796,.053-6.647l-.053-.053c-1.83-1.804-4.77-1.804-6.6,0l-15.4,15.4-6-6c-1.83-1.804-4.77-1.804-6.6,0-1.823,1.69-1.93,4.537-.241,6.359,.077,.083,.157,.163,.241,.241l9.3,9.4c1.83,1.804,4.77,1.804,6.6,0l18.7-18.7Z" fill-rule="evenodd">
-              //  </path>
-              // </svg>`;
-          svgClass = ' icon-svg-blue';
-          break
-        case 'sms':
-          //icon = 'bi-phone'
-          icon = 
-            `
+
+					svgClass = ' icon-svg-blue'
+					break
+				case 'sms':
+					icon = `
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-phone" viewBox="0 0 16 16">
                 <path d="M11 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h6zM5 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H5z"/>
                 <path d="M8 14a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"/>
               </svg>
             `
-          cpTitle = 'SMS'
-          cpSubTitle = checkpoint.message
-          break
-        case 'email':
-          //icon = 'bi-envelope'
-          icon = 
-            `
+					cpTitle = 'SMS'
+					cpSubTitle = checkpoint.message
+					break
+				case 'email':
+					attachmentsCode = ''
+					attachmentsLinks = ''
+					if (checkpoint.attachments.length != 0) {
+						for (const attach of checkpoint.attachments) {
+							attachmentsLinks = attachmentsLinks =
+								attachmentsLinks +
+								`<a href="${attach.url}">${attach.filename}</a><br />`
+						}
+						
+						attachmentsCode = `
+							<tr>
+								<td>Attachments:</td>
+      							<td>${attachmentsLinks}</td>
+							</tr>
+						`
+					}
+
+					emailPopover = `
+						<table class="table table-borderless" style="margin-top: 0.5rem; margin-bottom: 0.5rem">
+  							<tbody>
+								<tr>
+									<td style="padding-top: 0; padding-bottom: 0;">Opened:</td>
+      								<td style="padding-top: 0; padding-bottom: 0;">${oDate}</td>
+								</tr>
+								<tr>
+									<td style="padding-top: 0; padding-bottom: 0;">Clicked:</td>
+      								<td style="padding-top: 0; padding-bottom: 0;">${cDate}</td>
+								</tr>
+								${attachmentsCode}
+								<tr>
+									<td style="padding-top: 0; padding-bottom: 0;"><br />Resend <a href="#"><i class="bi bi-send"></i></a></td>
+								</tr>
+							</tbody>
+						</table>
+					`
+			
+					icon = `
+            <button type="button" class="btn po-${parcel.tracking_number}" data-bs-toggle="popover" data-bs-custom-class="custom-popover" data-bs-html="true" data-bs-content='${emailPopover}'>
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-envelope" viewBox="0 0 16 16">
                 <path d="M0 4a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V4Zm2-1a1 1 0 0 0-1 1v.217l7 4.2 7-4.2V4a1 1 0 0 0-1-1H2Zm13 2.383-4.708 2.825L15 11.105V5.383Zm-.034 6.876-5.64-3.471L8 9.583l-1.326-.795-5.64 3.47A1 1 0 0 0 2 13h12a1 1 0 0 0 .966-.741ZM1 11.105l4.708-2.897L1 5.383v5.722Z"/>
-            </svg>
+              </svg>
+            </button>
             `
 
-          if (typeof checkpoint.opened === 'string') {
-            oDate = new Date(checkpoint.opened).toLocaleString('en-US', {
-              month: 'long',
-              day: 'numeric',
-            })
-          } else {
-            oDate = '--'
-          }
-
-          if (typeof checkpoint.clicked === 'string') {
-            cDate = new Date(checkpoint.clicked).toLocaleString('en-US', {
-              month: 'long',
-              day: 'numeric',
-            })
-          } else {
-            cDate = '--'
-          }
-
-          if (checkpoint.from_other_tracking) {
-            emailClass = ' border p-1 bg-body-tertiary'; 
-            infoHtml = `
+					if (checkpoint.from_other_tracking) {
+						emailClass = ' border p-1 bg-body-tertiary'
+						infoHtml = `
                 <p class="text-max-w from-other-tracking"><span class="bi bi-info-circle-fill"> This notification belongs to another shipment of the same order.</span></p>
-              `;
-          }
-					
-          cpTitle = `<a id="tt-${pCounter}-${cp}" class="link-offset-2 link-underline link-underline-opacity-0 pl-tt" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-html="true" data-bs-title="<p>Opened: ${oDate}<br />Clicked: ${cDate}</p>" href="${checkpoint.rescueLink}" target="_blank">Email</a>`;
-          cpSubTitle = checkpoint.subject
-          break
-        case 'webhook':
-          //icon = 'bi-cloud-arrow-up'
-          icon = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-cloud-arrow-up" viewBox="0 0 16 16">
+              `
+					}
+
+					cpTitle = `<a id="tt-${pCounter}-${cp}" class="link-offset-2 link-underline link-underline-opacity-0" href="${checkpoint.rescueLink}" target="_blank" data-bs-toggle="tooltip" data-bs-title="The last tip!">Email</a>`
+					cpSubTitle = checkpoint.subject
+					break
+				case 'webhook':
+					//icon = 'bi-cloud-arrow-up'
+					icon = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-cloud-arrow-up" viewBox="0 0 16 16" >
   <path fill-rule="evenodd" d="M7.646 5.146a.5.5 0 0 1 .708 0l2 2a.5.5 0 0 1-.708.708L8.5 6.707V10.5a.5.5 0 0 1-1 0V6.707L6.354 7.854a.5.5 0 1 1-.708-.708l2-2z"/>
   <path d="M4.406 3.342A5.53 5.53 0 0 1 8 2c2.69 0 4.923 2 5.166 4.579C14.758 6.804 16 8.137 16 9.773 16 11.569 14.502 13 12.687 13H3.781C1.708 13 0 11.366 0 9.318c0-1.763 1.266-3.223 2.942-3.593.143-.863.698-1.723 1.464-2.383zm.653.757c-.757.653-1.153 1.44-1.153 2.056v.448l-.445.049C2.064 6.805 1 7.952 1 9.318 1 10.785 2.23 12 3.781 12h8.906C13.98 12 15 10.988 15 9.773c0-1.216-1.02-2.228-2.313-2.228h-.5v-.5C12.188 4.825 10.328 3 8 3a4.53 4.53 0 0 0-2.941 1.1z"/>
 </svg>`
-          cpTitle = 'Webhook'
-          cpSubTitle = checkpoint.message.event
-          break
-        default:
-          //icon = 'bi-truck'
-          icon = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-truck" viewBox="0 0 16 16">
+					cpTitle = 'Webhook'
+					cpSubTitle = checkpoint.message.event
+					break
+				default:
+					//icon = 'bi-truck'
+					icon = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-truck" viewBox="0 0 16 16">
   <path d="M0 3.5A1.5 1.5 0 0 1 1.5 2h9A1.5 1.5 0 0 1 12 3.5V5h1.02a1.5 1.5 0 0 1 1.17.563l1.481 1.85a1.5 1.5 0 0 1 .329.938V10.5a1.5 1.5 0 0 1-1.5 1.5H14a2 2 0 1 1-4 0H5a2 2 0 1 1-3.998-.085A1.5 1.5 0 0 1 0 10.5v-7zm1.294 7.456A1.999 1.999 0 0 1 4.732 11h5.536a2.01 2.01 0 0 1 .732-.732V3.5a.5.5 0 0 0-.5-.5h-9a.5.5 0 0 0-.5.5v7a.5.5 0 0 0 .294.456zM12 10a2 2 0 0 1 1.732 1h.768a.5.5 0 0 0 .5-.5V8.35a.5.5 0 0 0-.11-.312l-1.48-1.85A.5.5 0 0 0 13.02 6H12v4zm-9 1a1 1 0 1 0 0 2 1 1 0 0 0 0-2zm9 0a1 1 0 1 0 0 2 1 1 0 0 0 0-2z"/>
-</svg>`;
-      }
-      
-      console.log(date)
-      let lineCode = ''
-      if (cp != 0) {
-         lineCode = '<div class="line"></div>'
-      }
+</svg>`
+			}
 
-      
-      UX.addCheckpointDetails(
+			//console.log(date)
+			let lineCode = ''
+			if (cp != 0) {
+				lineCode = '<div class="line"></div>'
+			}
+
+			UX.addCheckpointDetails(
 				orderNo,
 				parcel.tracking_number,
 				date,
@@ -247,34 +282,28 @@ export function processJourneyCheckpoints(response, parcel, orderNo, pCounter) {
 				lineCode,
 				svgClass,
 				emailClass,
-        infoHtml
-			);
-
-      // if (cp != 0) {
-      //   UX.addCheckpointSpacer(orderNo, parcel.tracking_number);
-      // }
-    }
-  }
+				infoHtml,
+			)
+		}
+	}
 }
 
 $(document).ready(function () {
-  const lastResult = getLastResult
-  UX.readyPanel(options, lastResult)
+	const lastResult = getLastResult
+	UX.readyPanel(options, lastResult)
 
-  $('#search-btn').on('click', function () {
-    UX.cleanPanel()
+	$('#search-btn').on('click', function () {
+		UX.cleanPanel()
 		UX.startProgress()
-    const searchTerm = ($('#search-input').val() as string).trim()
-   
-  
+		const searchTerm = ($('#search-input').val() as string).trim()
 
-    if (searchTerm == '') {
-      UX.displayAlert(400)
-      $('#search-btn').prop('disabled', false)
-    } else if (isEmail(searchTerm)) {
-      getOrdersFromChatBotAPI(searchTerm, 'customerEmail', options)
-    } else {
-      getOrderByOrderNumber(searchTerm, options)
-    }
-  })
+		if (searchTerm == '') {
+			UX.displayAlert(400)
+			$('#search-btn').prop('disabled', false)
+		} else if (isEmail(searchTerm)) {
+			getOrdersFromChatBotAPI(searchTerm, 'customerEmail', options)
+		} else {
+			getOrderByOrderNumber(searchTerm, options)
+		}
+	})
 })

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,31 +1,31 @@
 export interface StorageOptions {
-  user: string
-  token: string
-  language: string
+	user: string
+	token: string
+	language: string
 }
 
 export function getOptions(): StorageOptions {
-  return {
-    user: localStorage.getItem('user'),
-    token: localStorage.getItem('token'),
-    language: localStorage.getItem('language')
-  }
+	return {
+		user: localStorage.getItem('user'),
+		token: localStorage.getItem('token'),
+		language: localStorage.getItem('language'),
+	}
 }
 
 export function getLastResult(): string {
-  return localStorage.getItem('lastResult')
+	return localStorage.getItem('lastResult')
 }
 
 export function setOptions(options: StorageOptions) {
-  localStorage.setItem('user', options.user)
-  localStorage.setItem('token', options.token)
-  localStorage.setItem('language', options.language)
+	localStorage.setItem('user', options.user)
+	localStorage.setItem('token', options.token)
+	localStorage.setItem('language', options.language)
 }
 
 export function setLastResult(lastResult: string) {
-  localStorage.setItem('lastResult', lastResult)
+	localStorage.setItem('lastResult', lastResult)
 }
 
 export function clearLastResult() {
-  localStorage.removeItem('lastResult')
+	localStorage.removeItem('lastResult')
 }

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -1,42 +1,45 @@
 export function mergeAndSortAscendingDate(arrA, arrB) {
-  return [...arrA, ...arrB].sort(
-    (objA, objB) =>
-      Number(new Date(objA.timestamp)) - Number(new Date(objB.timestamp))
-  )
+	return [...arrA, ...arrB].sort(
+		(objA, objB) =>
+			Number(new Date(objA.timestamp)) - Number(new Date(objB.timestamp)),
+	)
 }
 
 export function sortByColorPriority(arr) {
 	return arr.sort(
 		(a, b) => a.actionBox.colorPriority - b.actionBox.colorPriority,
-	);
+	)
 }
 
 export function filterHiddenEvents(arr) {
-  return arr.filter(function (obj) {
-    //if (obj.hasOwnProperty('type')) {
-    if (Object.prototype.hasOwnProperty.call(obj, 'type')) {
-      return obj
-    } else if (Object.prototype.hasOwnProperty.call(obj, 'shown') && obj.shown) {
-      return obj
-    }
-  })
+	return arr.filter(function (obj) {
+		//if (obj.hasOwnProperty('type')) {
+		if (Object.prototype.hasOwnProperty.call(obj, 'type')) {
+			return obj
+		} else if (
+			Object.prototype.hasOwnProperty.call(obj, 'shown') &&
+			obj.shown
+		) {
+			return obj
+		}
+	})
 }
 
 export function isEmail(input) {
-  const validRegex =
-    /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/
+	const validRegex =
+		/^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/
 
-  if (input.match(validRegex)) {
-    return true
-  } else {
-    return false
-  }
+	if (input.match(validRegex)) {
+		return true
+	} else {
+		return false
+	}
 }
 
 export function subtractDays(date, days) {
-  const dateCopy = new Date(date)
+	const dateCopy = new Date(date)
 
-  dateCopy.setDate(dateCopy.getDate() - days)
+	dateCopy.setDate(dateCopy.getDate() - days)
 
-  return dateCopy
+	return dateCopy
 }

--- a/styles/common.scss
+++ b/styles/common.scss
@@ -45,10 +45,6 @@
 }
 
 
-.item-box p{
-    //color: #747ba9;
-    
-}
 
 
 .main-item{
@@ -63,12 +59,7 @@
     margin-bottom: 0;
 }
 
-.main-item a{
-    //color: var(--black-100);
-}
-.main-item p {
-    //color: #9ca3af;
-}
+
 .main-box li{
     list-style: none;
 }
@@ -146,4 +137,14 @@ li.item-1 {
 
 .date {
     white-space: nowrap;
+}
+
+.custom-popover {
+  --bs-popover-max-width: 200px;
+  --bs-popover-border-color: var(--bs-primary);
+  --bs-popover-header-bg: var(--bs-primary);
+  --bs-popover-header-color: var(--bs-white);
+  --bs-popover-body-padding-x: 1rem;
+  --bs-popover-body-padding-y: .5rem;
+  font-size: 11px;
 }

--- a/webpack.common.cjs
+++ b/webpack.common.cjs
@@ -7,77 +7,78 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const ESLintPlugin = require('eslint-webpack-plugin')
 
 module.exports = {
-  entry: {
-    popup: './src/popup.ts',
-    options: './src/options.ts',
-  },
-  module: {
-    rules: [
-      {
-        test: /\.woff($|\?)|\.woff2($|\?)|\.ttf($|\?)|\.eot($|\?)|\.svg($|\?)/i,
-        type: 'asset/resource',
-        generator: {
-          filename: 'fonts/[name][ext][query]',
-        },
-      },
-      // {
-      //   test: /\.ts?$/,
-      //   use: 'ts-loader',
-      //   exclude: /node_modules/,
-      // },
-      {
-        test: /\.(js|ts)x?$/,
-        use: ['babel-loader'],
-        exclude: /node_modules/,
-      },
-      {
-        test: /\.(jpg|jpeg|png|eot|ttf|svg)$/,
-        type: 'asset/resource',
-      },
-      {
-        test: /\.(scss|css)$/,
-        use: [
-          MiniCssExtractPlugin.loader,
-          {
-            loader: 'css-loader',
-          },
-          {
-            loader: 'postcss-loader',
-            options: {
-              postcssOptions: {
-                plugins: () => [autoprefixer],
-              },
-            },
-          },
-          {
-            loader: 'sass-loader',
-          },
-        ],
-      },
-    ],
-  },
-  resolve: {
-    extensions: ['.ts', '.js'],
-  },
-  output: {
-    filename: '[name].js',
-    path: path.resolve('dist'),
-  },
-  plugins: [
-    new CopyPlugin({
-      patterns: [{ from: 'static' }],
-    }),
-    new webpack.ProvidePlugin({
-      $: 'jquery',
-      jQuery: 'jquery',
-    }),
-    new MiniCssExtractPlugin({
-      filename: 'styles/[name].css',
-    }),
-    new ESLintPlugin({
-      extensions: ['js', 'ts'],
-      fix: true,
-      overrideConfigFile: path.resolve(__dirname, '.eslintrc'),
-    }),
-  ],
-}
+	entry: {
+		popup: './src/popup.ts',
+		options: './src/options.ts',
+	},
+	module: {
+		rules: [
+			{
+				test: /\.woff($|\?)|\.woff2($|\?)|\.ttf($|\?)|\.eot($|\?)|\.svg($|\?)/i,
+				type: 'asset/resource',
+				generator: {
+					filename: 'fonts/[name][ext][query]',
+				},
+			},
+			// {
+			//   test: /\.ts?$/,
+			//   use: 'ts-loader',
+			//   exclude: /node_modules/,
+			// },
+			{
+				test: /\.(js|ts)x?$/,
+				use: ['babel-loader'],
+				exclude: /node_modules/,
+			},
+			{
+				test: /\.(jpg|jpeg|png|eot|ttf|svg)$/,
+				type: 'asset/resource',
+			},
+			{
+				test: /\.(scss|css)$/,
+				use: [
+					MiniCssExtractPlugin.loader,
+					{
+						loader: 'css-loader',
+					},
+					{
+						loader: 'postcss-loader',
+						options: {
+							postcssOptions: {
+								plugins: () => [autoprefixer],
+							},
+						},
+					},
+					{
+						loader: 'sass-loader',
+					},
+				],
+			},
+		],
+	},
+	resolve: {
+		extensions: ['.ts', '.js'],
+	},
+	output: {
+		filename: '[name].js',
+		path: path.resolve('dist'),
+	},
+	plugins: [
+		new CopyPlugin({
+			patterns: [{ from: 'static' }],
+		}),
+		new webpack.ProvidePlugin({
+			$: 'jquery',
+			jQuery: 'jquery',
+			//Popper: ['popper.js', 'default'],
+		}),
+		new MiniCssExtractPlugin({
+			filename: 'styles/[name].css',
+		}),
+		new ESLintPlugin({
+			extensions: ['js', 'ts'],
+			fix: true,
+			overrideConfigFile: path.resolve(__dirname, '.eslintrc'),
+		}),
+	],
+};


### PR DESCRIPTION
feat: added email popovers
chore: cleaned up semicolons

Changes to be committed:
	modified:   .prettierrc
	modified:   src/api.ts
	modified:   src/options.ts
	modified:   src/popup.ts
	modified:   src/storage.ts
	modified:   src/utility.ts
	modified:   src/ux.ts
	modified:   styles/common.scss
	modified:   webpack.common.cjs

<!--- Provide a general summary of your changes -->
<!--- Write the related JIRA issue here with the [PROJ-123] format if applicable -->
<!--- If suggesting a new feature or change, please discuss it in the issue first -->

## Description
Added a popover element to the result pane that allows you to click the email icon and get information about the engagement with that email.  Will enable re-send support in the future.

<!--- Why is this change required? What problem does it solve? -->
<!--- Describe your changes in detail -->
<!--- Include details of how you tested the change -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
